### PR TITLE
Update DatabaseSeeder.stub

### DIFF
--- a/src/stubs/database/seeds/DatabaseSeeder.stub
+++ b/src/stubs/database/seeds/DatabaseSeeder.stub
@@ -11,7 +11,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-         $this->call(UsersTableSeeder::class);
-         $this->call(ClientsTableSeeder::class);
+         $this->call([
+            UsersTableSeeder::class,
+            ClientsTableSeeder::class
+         ]);
     }
 }


### PR DESCRIPTION
call function accepts array as parameter. 
This should be the correct usage.
I am using Laravel Laravel Framework 6.4.0
![image](https://user-images.githubusercontent.com/510560/67635198-399fb080-f8d5-11e9-9915-b777627d7391.png)
